### PR TITLE
fix flickering when hovers on categories

### DIFF
--- a/epoch_drops_web/app/globals.css
+++ b/epoch_drops_web/app/globals.css
@@ -23,4 +23,7 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  min-height: 100vh;
+  min-width: 100vw;
+  overflow-x: hidden;
 }


### PR DESCRIPTION
The flickering that occurred when hovering over one of the categories with the most subcategories should be resolved with this small change. What’s still missing is handling the category size — I think it would be best to add a scroll so the page doesn’t expand vertically, but that’s something for another pull request since it involves touching Next.js files with dynamic content.

Cheers!!